### PR TITLE
Alternate encoder pins

### DIFF
--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/I2C.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/I2C.h
@@ -222,7 +222,7 @@ static AnalogScanner scanner;
 static void i2c_get_analog_values() {
   if (millis() > next_analog_read_time) {
     for (int i = 0; i < ANALOG_NUM; i++) {
-      unsigned int v = scanner.getValue(i);
+      unsigned int v = analogRead(i);
       unsigned char addr = 0x58 + i * 2;
 
       i2c_buffer[addr    ] =  v        & 0xff;

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
@@ -61,6 +61,7 @@
 
    /* The A-Star 32U4 Robot Controller LV with Raspberry Pi Bridge */
    #define POLOLU_ASTAR_ROBOT_CONTROLLER
+   //#define USE_ENABLE_INTERRUPT
 
    /* The RoboGaia encoder shield */
    //#define ROBOGAIA
@@ -81,10 +82,11 @@
 /* Maximum PWM signal */
 #define MAX_PWM        255
 
-/* MARCO: The POLOLU_DRV8835 has a range +/- 400, but I'm running 6V motors
-   on 7.4V batteries, so I limit it here to 6/7.4 * 400
-*/
-#define MAX_PWM        325
+// merose: The A-Star has a PWM range of +/- 400 for the motors. Pololu
+// calls them 6V motors, so Marco originally reduced the maximum PWM
+// based on using 7.4V batteries. But Ray looked up the motor specs and
+// found they are rated to 12V, so we'll use the maximum PWM available.
+#define MAX_PWM        400
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/encoder_driver.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/encoder_driver.h
@@ -14,11 +14,25 @@
 
 #elif defined POLOLU_ASTAR_ROBOT_CONTROLLER
 
+ #ifndef USE_ENABLE_INTERRUPT
   #define LEFT_ENC_PIN_XOR 8   // D8
   #define LEFT_ENC_PIN_B   11  // D11
 
   #define RIGHT_ENC_PIN_XOR 7  // D7
   #define RIGHT_ENC_PIN_B   5  // D5
+ #endif
+  // Alternate pin definitions for using the EnableInterrupt library for
+  // using pin-change interrupts. All these pins are capable of either
+  // hardware interrupts or pin-change interrupts (or both) on the A-Star.
+  // They also avoid all analog pins, in case more analog sensors are added.
+  // (Note that the right encoder pins are a misnomer: actually pin 15 is
+  // the "A" encoder output of the motors and 16 is "B". They are switched
+  // here because the right motor is reversed. This allows the encoder to
+  // count positively for forward movement on each wheel.)
+  #define LEFT_ENC_PIN_A    7
+  #define LEFT_ENC_PIN_B    11
+  #define RIGHT_ENC_PIN_A   16
+  #define RIGHT_ENC_PIN_B   15
 #endif
 
 void initEncoder();


### PR DESCRIPTION
Added an optional, alternate encoder pin wiring, using the EnableInterrupt library to interrupt on the "A" encoder inputs only.
